### PR TITLE
BUG: Fixed adapter channel name if several channels in use

### DIFF
--- a/src/QueueFactory.php
+++ b/src/QueueFactory.php
@@ -76,7 +76,7 @@ final class QueueFactory implements QueueFactoryInterface
         if (isset($this->channelConfiguration[$channel])) {
             $definition = $this->channelConfiguration[$channel];
             $this->checkDefinitionType($channel, $definition);
-            $adapter = $this->createFromDefinition($channel, $definition);
+            $adapter = $this->createFromDefinition($channel, $definition)->withChannel($channel);
 
             return $this->queue->withChannelName($channel)->withAdapter($adapter);
         }


### PR DESCRIPTION
Fixed adapter channel name if several channels in use and adapter created from container definitions:
use the same way as default adapter below.