### PR TITLE
Envelope trait fixed to be compatible with EnvelopeInterface.

### DIFF
--- a/src/Message/EnvelopeTrait.php
+++ b/src/Message/EnvelopeTrait.php
@@ -13,7 +13,7 @@ trait EnvelopeTrait
         return $this->message;
     }
 
-    public function withMessage(MessageInterface $message): self
+    public function withMessage(MessageInterface $message): EnvelopeInterface
     {
         $instance = clone $this;
         $instance->message = $message;
@@ -31,9 +31,9 @@ trait EnvelopeTrait
         return $this->message->getData();
     }
 
-    public static function fromMessage(MessageInterface $message): self
+    public static function fromMessage(MessageInterface $message): EnvelopeInterface
     {
-        return new static($message);
+        return new IdEnvelope($message);
     }
 
     public function getMetadata(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌


[2024-05-26 18:37:09] main.ALERT: Fatal Error (E_COMPILE_ERROR): Declaration of Yiisoft\Queue\Message\IdEnvelope::fromMessage(Yiisoft\Queue\Message\MessageInterface $message): Yiisoft\Queue\Message\IdEnvelope must be compatible with Yiisoft\Queue\Message\EnvelopeInterface::fromMessage(Yiisoft\Queue\Message\MessageInterface $message): Yiisoft\Queue\Message\EnvelopeInterface
