### PR TITLE
Add community maintained adapters to the list of queue adapters

### DIFF
--- a/docs/guide/en/adapter-list.md
+++ b/docs/guide/en/adapter-list.md
@@ -4,3 +4,4 @@ Queue Adapters
 * [Synchronous](adapter-sync.md) - adapter for development and test environments
 * [AMQP](https://github.com/yiisoft/queue-amqp) - adapter over AMQP protocol via [amqplib](https://github.com/php-amqplib/php-amqplib)
 * [NATS](https://github.com/g41797/queue-nats) - [NATS](https://nats.io/) JetStream adapter
+* [Pulsar](https://github.com/g41797/queue-pulsar) - [Apache Pulsar](https://pulsar.apache.org/) adapter

--- a/docs/guide/en/adapter-list.md
+++ b/docs/guide/en/adapter-list.md
@@ -3,5 +3,8 @@ Queue Adapters
 
 * [Synchronous](adapter-sync.md) - adapter for development and test environments
 * [AMQP](https://github.com/yiisoft/queue-amqp) - adapter over AMQP protocol via [amqplib](https://github.com/php-amqplib/php-amqplib)
+
+
+There are other queue adapters contributed and maintained by the community and available on GitHub, such as:
 * [NATS](https://github.com/g41797/queue-nats) - [NATS](https://nats.io/) JetStream adapter
 * [Pulsar](https://github.com/g41797/queue-pulsar) - [Apache Pulsar](https://pulsar.apache.org/) adapter


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | V

[NATS](https://github.com/g41797/queue-nats) - [NATS](https://nats.io/) JetStream adapter
[Pulsar](https://github.com/g41797/queue-pulsar) - [Apache Pulsar](https://pulsar.apache.org/) adapter
