### PR TITLE
Change `QueueInterface::getChannel()` result type to string only

### DIFF
--- a/src/Debug/QueueCollector.php
+++ b/src/Debug/QueueCollector.php
@@ -67,7 +67,7 @@ final class QueueCollector implements SummaryCollectorInterface
         if (!$this->isActive()) {
             return;
         }
-        $this->processingMessages[$queue->getChannel() ?? 'null'][] = $message;
+        $this->processingMessages[$queue->getChannel()][] = $message;
     }
 
     private function reset(): void

--- a/src/Debug/QueueDecorator.php
+++ b/src/Debug/QueueDecorator.php
@@ -50,7 +50,7 @@ final class QueueDecorator implements QueueInterface
         return new self($this->queue->withAdapter($adapter), $this->collector);
     }
 
-    public function getChannel(): ?string
+    public function getChannel(): string
     {
         return $this->queue->getChannel();
     }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue;
 
+use LogicException;
 use Psr\Log\LoggerInterface;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\Cli\LoopInterface;
@@ -37,9 +38,13 @@ final class Queue implements QueueInterface
         $this->adapterPushHandler = new AdapterPushHandler();
     }
 
-    public function getChannel(): ?string
+    public function getChannel(): string
     {
-        return $this->adapter?->getChannel();
+        if ($this->adapter === null) {
+            throw new LogicException('Adapter is not set.');
+        }
+
+        return $this->adapter->getChannel();
     }
 
     public function push(

--- a/src/QueueInterface.php
+++ b/src/QueueInterface.php
@@ -45,5 +45,5 @@ interface QueueInterface
 
     public function withAdapter(AdapterInterface $adapter): self;
 
-    public function getChannel(): ?string;
+    public function getChannel(): string;
 }

--- a/stubs/StubQueue.php
+++ b/stubs/StubQueue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Stubs;
 
+use LogicException;
 use Yiisoft\Queue\Adapter\AdapterInterface;
 use Yiisoft\Queue\JobStatus;
 use Yiisoft\Queue\Message\MessageInterface;
@@ -53,8 +54,12 @@ final class StubQueue implements QueueInterface
         return $new;
     }
 
-    public function getChannel(): ?string
+    public function getChannel(): string
     {
+        if ($this->adapter === null) {
+            throw new LogicException('Adapter is not set.');
+        }
+
         return $this->adapter?->getChannel();
     }
 }

--- a/tests/Unit/Stubs/StubQueueTest.php
+++ b/tests/Unit/Stubs/StubQueueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Queue\Tests\Unit\Stubs;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Queue\JobStatus;
 use Yiisoft\Queue\Message\Message;
@@ -20,9 +21,17 @@ final class StubQueueTest extends TestCase
         $this->assertSame($message, $queue->push($message));
         $this->assertSame(0, $queue->run());
         $this->assertSame(JobStatus::DONE, $queue->status('test'));
-        $this->assertNull($queue->getChannel());
         $this->assertNull($queue->getAdapter());
         $queue->listen();
+    }
+
+    public function testGetChannelWithoutAdapter(): void
+    {
+        $queue = new StubQueue();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Adapter is not set.');
+        $queue->getChannel();
     }
 
     public function testWithAdapter(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
