### PR TITLE
Change `Worker::process()` return type to `void`

### DIFF
--- a/src/Debug/QueueWorkerInterfaceProxy.php
+++ b/src/Debug/QueueWorkerInterfaceProxy.php
@@ -8,6 +8,9 @@ use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\QueueProducerInterface;
 use Yiisoft\Queue\Worker\WorkerInterface;
 
+/**
+ * Debug proxy for {@see WorkerInterface} that records processed messages into the {@see QueueCollector}.
+ */
 final class QueueWorkerInterfaceProxy implements WorkerInterface
 {
     public function __construct(
@@ -19,8 +22,8 @@ final class QueueWorkerInterfaceProxy implements WorkerInterface
         MessageInterface $message,
         string $queueName,
         ?QueueProducerInterface $retryProducer = null,
-    ): MessageInterface {
+    ): void {
         $this->collector->collectWorkerProcessing($message, $queueName);
-        return $this->worker->process($message, $queueName, $retryProducer);
+        $this->worker->process($message, $queueName, $retryProducer);
     }
 }

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -34,7 +34,7 @@ final class Worker implements WorkerInterface
         MessageInterface $message,
         string $queueName,
         ?QueueProducerInterface $retryProducer = null,
-    ): MessageInterface {
+    ): void {
         $messageId = IdEnvelope::fromMessage($message)->getId();
         if ($messageId === null) {
             $this->logger->info('Processing message without ID.');
@@ -46,15 +46,13 @@ final class Worker implements WorkerInterface
         try {
             $handler = $this->handlerResolver->resolve($message->getType());
             $finishHandler = new ConsumeFinalHandler($handler->handle(...));
-            return $this->consumeMiddlewareDispatcher->dispatch($request, $finishHandler)->getMessage();
+            $this->consumeMiddlewareDispatcher->dispatch($request, $finishHandler);
         } catch (Throwable $exception) {
             $request = new FailureHandlingRequest($request->getMessage(), $exception, $request->getQueueName(), $retryProducer);
 
             try {
-                $result = $this->failureMiddlewareDispatcher->dispatch($request, new FailureFinalHandler());
+                $this->failureMiddlewareDispatcher->dispatch($request, new FailureFinalHandler());
                 $this->logger->info($exception->getMessage());
-
-                return $result->getMessage();
             } catch (Throwable $exception) {
                 $exception = new MessageFailureException($message, $exception);
                 $this->logger->error($exception->getMessage());

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -7,12 +7,17 @@ namespace Yiisoft\Queue\Worker;
 use Yiisoft\Queue\Message\MessageInterface;
 use Yiisoft\Queue\QueueProducerInterface;
 
+/**
+ * Executes a message: runs it through the consume pipeline and, on failure, through the failure pipeline.
+ */
 interface WorkerInterface
 {
-    /** @param string $queueName Logical execution queue name. */
+    /**
+     * @param string $queueName Logical execution queue name.
+     */
     public function process(
         MessageInterface $message,
         string $queueName,
         ?QueueProducerInterface $retryProducer = null,
-    ): MessageInterface;
+    ): void;
 }

--- a/stubs/StubWorker.php
+++ b/stubs/StubWorker.php
@@ -17,7 +17,5 @@ final class StubWorker implements WorkerInterface
         MessageInterface $message,
         string $queueName,
         ?QueueProducerInterface $retryProducer = null,
-    ): MessageInterface {
-        return $message;
-    }
+    ): void {}
 }

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -95,17 +95,24 @@ final class MiddlewareTest extends TestCase
             [],
         );
 
+        $handledMessage = null;
         $worker = new Worker(
             new SimpleLogger(),
             $consumeMiddlewareDispatcher,
             $failureMiddlewareDispatcher,
-            new HandlerResolver(['test' => static fn() => true], $container),
+            new HandlerResolver(
+                ['test' => static function (MessageInterface $message) use (&$handledMessage): void {
+                    $handledMessage = $message;
+                }],
+                $container,
+            ),
         );
 
         $message = new GenericMessage('test', ['initial']);
-        $messageConsumed = $worker->process($message, 'test-queue');
+        $worker->process($message, 'test-queue');
 
-        self::assertEquals($stack, $messageConsumed->getPayload());
+        self::assertInstanceOf(MessageInterface::class, $handledMessage);
+        self::assertEquals($stack, $handledMessage->getPayload());
     }
 
     public function testFullStackFailure(): void

--- a/tests/Unit/Debug/QueueWorkerInterfaceProxyTest.php
+++ b/tests/Unit/Debug/QueueWorkerInterfaceProxyTest.php
@@ -19,9 +19,7 @@ final class QueueWorkerInterfaceProxyTest extends TestCase
         $collector->startup();
         $proxy = new QueueWorkerInterfaceProxy(new StubWorker(), $collector);
 
-        $result = $proxy->process($message, 'chan');
-
-        self::assertSame($message, $result);
+        $proxy->process($message, 'chan');
 
         $collected = $collector->getCollected();
         self::assertArrayHasKey('processingMessages', $collected);

--- a/tests/Unit/Stubs/StubWorkerTest.php
+++ b/tests/Unit/Stubs/StubWorkerTest.php
@@ -12,15 +12,9 @@ final class StubWorkerTest extends TestCase
 {
     public function testBase(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $worker = new StubWorker();
-
-        $sourceMessage = new GenericMessage('test', 42);
-
-        $message = $worker->process($sourceMessage, 'test-queue');
-
-        $this->assertSame($sourceMessage, $message);
-        $this->assertSame('test', $message->getType());
-        $this->assertSame(42, $message->getPayload());
-        $this->assertSame([], $message->getMeta());
+        $worker->process(new GenericMessage('test', 42), 'test-queue');
     }
 }

--- a/tests/Unit/WorkerTest.php
+++ b/tests/Unit/WorkerTest.php
@@ -94,7 +94,13 @@ final class WorkerTest extends TestCase
         $finalMessage = new GenericMessage('final', null);
         /** @var FailureMiddlewareInterface&MockObject $failureMiddleware */
         $failureMiddleware = $this->createMock(FailureMiddlewareInterface::class);
-        $failureMiddleware->method('processFailure')->willReturn(new FailureHandlingRequest($finalMessage, $originalException, $queueName));
+        $failureMiddleware
+            ->expects(self::once())
+            ->method('processFailure')
+            ->with(self::callback(
+                static fn(FailureHandlingRequest $request): bool => $request->getException() === $originalException,
+            ))
+            ->willReturn(new FailureHandlingRequest($finalMessage, $originalException, $queueName));
 
         /** @var FailureMiddlewareFactoryInterface&MockObject $failureMiddlewareFactory */
         $failureMiddlewareFactory = $this->createMock(FailureMiddlewareFactoryInterface::class);
@@ -104,9 +110,7 @@ final class WorkerTest extends TestCase
         $handlerResolver = $this->createHandlerResolver($message, static fn() => null);
         $worker = $this->createWorkerByParams($handlerResolver, new NullLogger(), $consumeDispatcher, $failureDispatcher);
 
-        $result = $worker->process($message, $queueName);
-
-        self::assertSame($finalMessage, $result);
+        $worker->process($message, $queueName);
     }
 
     public function testUnresolvableHandlerIsHandledByFailurePipeline(): void
@@ -133,9 +137,7 @@ final class WorkerTest extends TestCase
 
         $worker = $this->createWorkerByParams($handlerResolver, failureMiddlewareDispatcher: $failureDispatcher);
 
-        $result = $worker->process($message, $queueName);
-
-        self::assertSame($finalMessage, $result);
+        $worker->process($message, $queueName);
     }
 
     private function createHandlerResolver(MessageInterface $message, callable $handler): HandlerResolver


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️